### PR TITLE
Fix test project reference path

### DIFF
--- a/PatternLibrary/PatternLibrary.Tests/PatternLibrary.Tests.csproj
+++ b/PatternLibrary/PatternLibrary.Tests/PatternLibrary.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PatternLibrary.csproj" />
+    <!-- Corrected relative path to the library project -->
+    <ProjectReference Include="..\PatternLibrary\PatternLibrary.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix path to PatternLibrary project in PatternLibrary.Tests.csproj

## Testing
- `dotnet test PatternLibrary/PatternLibrary.sln`


------
https://chatgpt.com/codex/tasks/task_e_68595ac5c5288322b1a506575e242e4e